### PR TITLE
Added a package.json, simplifies install instructions to just 'npm install'

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ JSON Operational Transform (JOT)
 This module implements operational transform on a JSON data model, in
 JavaScript for node.js and browsers.
 
-Basically this is the core of real time simultaneous editing, like Etherpad, 
+Basically this is the core of real time simultaneous editing, like Etherpad,
 but for structured data rather than just plain text. Since everything can
 be represented in JSON, this provides a superset of plain text collaboration
 functionality.
@@ -29,7 +29,7 @@ Here's an example of what this is all about. Say you start with:
 		"key1": "Hello world!",
 		"key2": 10
 	}
-	
+
 Then user A makes the following changes:
 
 	{
@@ -49,7 +49,7 @@ structurally:
 
 	A = [("rename" : "key1" => "title"), ("rename" : "key2" => "count")]
 	B = [("set" : "key1" => "My Program"), ("set" : "key2" => 20)]
-	
+
 If you were to apply these changes in sequence, you would have a problem.
 By the time you get to B's changes, the keys "key1" and "key2" are no
 longer there!
@@ -69,8 +69,8 @@ for use in browsers.
 
 Before running anything, you'll need to install the dependencies:
 
-	npm install deep-equal googlediff socket.io
-	
+	npm install
+
 To build the library for browsers, use:
 
 	nodejs build_browser_lib.js > jot.js
@@ -79,37 +79,37 @@ Example
 -------
 
 Here's example code that follows the example in the introduction:
-	
+
 	/* helpers and libraries */
 	function clone(obj) { return JSON.parse(JSON.stringify(obj)); }
 	var ot = require("./jot/base.js");
 	var spyobj = require("./jot/spyobject.js");
-	
+
 	/* here's the initial document */
 	var doc = {
 		key1: "Hello World!",
 		key2: 10,
 	};
-	
+
 	/* User 1 Makes Changes */
 	var d1 = new spyobj.SpyObject(clone(doc));
 	d1.rename("key1", "title");
 	d1.rename("key2", "count");
-	
+
 	// d1 is now { title: 'Hello World!', count: 10 }
-	
+
 	/* User 2 Makes Changes */
 	var d2 = new spyobj.SpyObject(clone(doc));
 	d2.set("key1", "My Program");
 	d2.inc("key2", 10); // an atomic increment!
-	
+
 	// d2 is now { key1: 'My Program', key2: 20 }
-	
+
 	/* Merge the Changes */
-	
+
 	var r1 = d1.pop_history();
 	ot.apply_array(r1, doc);
-	
+
 	var r2 = d2.pop_history();
 	r2 = ot.rebase_array(r1, r2);
 	ot.apply_array(r2, doc);
@@ -119,12 +119,12 @@ Here's example code that follows the example in the introduction:
 To run:
 
 	nodejs example.js
-	
+
 Note how the output applies both changes logically, even though the second
 change was specified as a change to key1, but that key doesn't exist by
 the time the change is applied. It's the atomic_rebase call that takes
 care of that.
-	
+
 An initial document (doc) is created. Changes are *simultaneously* made to
 doc. Here we're using a utility class SpyObject which records the revisions
 taken on it. SpoyObject.pop_history() returns the history of revisions made
@@ -149,9 +149,8 @@ JSONEditor (https://github.com/josdejong/jsoneditor).
 
 To run the interactive example, you'll also need get dependencies:
 
-	npm install connect
 	json_editor_example/get_json_editor.sh
-	
+
 Then build jot.js, our library suitable for use within the browser:
 
 	nodejs build_browser_lib.js > json_editor_example/jot.js
@@ -160,7 +159,7 @@ Start an HTTP server which will serve the static files and also act
 as a websockets server to handle the communication between the editors.
 
 	nodejs start.js
-	
+
 Finally, open http://localhost:8080/ in as many browser windows as you
 like and start editing.
 
@@ -210,7 +209,7 @@ it's what you do when you have two concurrent edits. For instance:
   operations can be combined so the value is incremented by two.
 * When text is edited, insertions using SPLICE at different locations in the text can be
   combined (like a typical merge or patch).
-  
+
 This is all put together in the CollaborationServer class which manages the state
 needed to pass operations around between any number of concurrent editors. The library
 is also used on the client side to merge incoming remote changes with what has already

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "jot",
+
+  "dependencies": {
+      "socket.io": "*",
+      "googlediff": "*",
+      "deep-equal": "*"
+  },
+
+  "devDependencies": {
+    "connect": "*"
+  }
+}


### PR DESCRIPTION
Adding a package.json means that running `npm install` will install all dependencies mentioned in the `dependencies` and `devDependencies` field. I added `connect` as a dev dependency, but the distinction isn't meaningful beyond aesthetic unless you package and publish `jot` as a npm module.

I updated the README to use a single `npm install` command, and to remove the extra command before setting up the editor.
