### PR TITLE
jot.LIST did not serialize and deserialize properly; LISTs stay lists

### DIFF
--- a/jot/index.js
+++ b/jot/index.js
@@ -65,12 +65,20 @@ exports.BaseOperation.prototype.toJsonableObject = function() {
 	var keys = Object.keys(this);
 	for (var i = 0; i < keys.length; i++) {
 		var v;
-		if (this[keys[i]] instanceof exports.BaseOperation)
+		if (this[keys[i]] instanceof exports.BaseOperation) {
 			v = this[keys[i]].toJsonableObject();
-		else if (typeof this[keys[i]] != 'undefined')
+        }
+        else if (keys[i] === 'ops' && Array.isArray(this[keys[i]])) {
+            v = this[keys[i]].map(function(ki) {
+                return ki.toJsonableObject();
+            });
+        }
+		else if (typeof this[keys[i]] !== 'undefined') {
 			v = this[keys[i]];
-		else
+        }
+		else {
 			continue;
+        }
 		repr[keys[i]] = v
 	}
 	return repr;
@@ -100,8 +108,13 @@ exports.opFromJsonableObject = function(obj, op_map) {
 	// Reconstruct.
 	var constructor = op_map[obj._type.module][obj._type.class];
 	var args = constructor.prototype.constructor_args.map(function(item) {
-		if (typeof obj[item] == 'object' && '_type' in obj[item])
+		if (typeof obj[item] == 'object' && '_type' in obj[item]) {
 			return exports.opFromJsonableObject(obj[item]);
+        } else if (item === 'ops' && Array.isArray(obj[item])) {
+            obj[item] = obj[item].map(function(op) {
+                return exports.opFromJsonableObject(op);
+            });
+        }
 		return obj[item];
 	});
 	var op = Object.create(constructor.prototype);

--- a/jot/meta.js
+++ b/jot/meta.js
@@ -22,8 +22,10 @@ jot.add_op(exports.LIST, exports, 'LIST', ['ops']);
 
 exports.LIST.prototype.apply = function (document) {
 	/* Applies the operation to a document.*/
-	for (var i = 0; i < this.ops.length; i++)
+	for (var i = 0; i < this.ops.length; i++) {
+        console.log('[JOT]', this.ops[i]);
 		document = this.ops[i].apply(document);
+    }
 	return document;
 }
 
@@ -101,7 +103,7 @@ exports.LIST.prototype.compose = function (other) {
 
 	// Nothing here anyway, return the other.
 	if (this.ops.length == 0)
-		return other;
+		return new exports.LIST([other]);
 
 	// the next operation is a no-op, so the composition is just this
 	if (other instanceof values.NO_OP)

--- a/tests/meta.js
+++ b/tests/meta.js
@@ -1,0 +1,40 @@
+var test = require('tap').test;
+var jot = require("../jot");
+var values = require("../jot/values.js");
+var seqs = require("../jot/sequences.js");
+var objs = require("../jot/objects.js");
+var meta = require("../jot/meta.js");
+
+test('meta', function(t) {
+    t.deepEqual(
+        jot.deserialize(
+            new meta.LIST([
+                new jot.OBJECT_APPLY(
+                    'foo', new jot.PUT(
+                        'x', 'y'
+                    )
+                ),
+
+                new jot.ARRAY_APPLY(
+                    'bar', new jot.INS(
+                        0, [{baz: 'quux'}]
+                    )
+                )
+            ]).serialize()
+        ),
+        new meta.LIST([
+            new jot.OBJECT_APPLY(
+                'foo', new jot.PUT(
+                    'x', 'y'
+                )
+            ),
+
+            new jot.ARRAY_APPLY(
+                'bar', new jot.INS(
+                    0, [{baz: 'quux'}]
+                )
+            )
+        ])
+    );
+    t.end();
+});

--- a/tests/meta.js
+++ b/tests/meta.js
@@ -6,6 +6,8 @@ var objs = require("../jot/objects.js");
 var meta = require("../jot/meta.js");
 
 test('meta', function(t) {
+
+    // (de)serialization
     t.deepEqual(
         jot.deserialize(
             new meta.LIST([
@@ -14,7 +16,6 @@ test('meta', function(t) {
                         'x', 'y'
                     )
                 ),
-
                 new jot.ARRAY_APPLY(
                     'bar', new jot.INS(
                         0, [{baz: 'quux'}]
@@ -28,7 +29,6 @@ test('meta', function(t) {
                     'x', 'y'
                 )
             ),
-
             new jot.ARRAY_APPLY(
                 'bar', new jot.INS(
                     0, [{baz: 'quux'}]
@@ -36,5 +36,6 @@ test('meta', function(t) {
             )
         ])
     );
+
     t.end();
 });


### PR DESCRIPTION
Child elements in the `ops` key were not serialized with their `_type` information. I added checks in `toJsonableObject` and `opFromJsonableObject` for cases where a key was named `ops` and satisfied `Array#isArray` - in those cases, the children were mapped over with the appropriate procedures.

Also in certain cases in the list `compose` method a non-list would be returned. If You need me to separate these into two commits or something I'm glad to but it was unintuitive behavior in practice.