### PR TITLE
[WIP] Rebase PATCH against MOVE

### DIFF
--- a/jot/index.js
+++ b/jot/index.js
@@ -33,6 +33,7 @@ exports.SET = function() { return new_op(values.SET, arguments) };
 exports.MATH = function() { return new_op(values.MATH, arguments) };
 exports.PATCH = function() { return new_op(sequences.PATCH, arguments) };
 exports.SPLICE = function() { return new_op(sequences.SPLICE, arguments) };
+exports.MOVE = function() { return new_op(sequences.MOVE, arguments) };
 exports.MAP = function() { return new_op(sequences.MAP, arguments) };
 exports.PUT = function() { return new_op(objects.PUT, arguments) };
 exports.REN = function() { return new_op(objects.REN, arguments) };

--- a/jot/sequences.js
+++ b/jot/sequences.js
@@ -752,15 +752,15 @@ If we have SPLICE hunks in:
 	- G H I: will ignore length changes in D E F
 	- J K L: will not be affected by MOVE  */
 	
-	[exports.MOVE, function(other, conflictless) {
-		var splice = [];
-		var pos = other.pos;
-		var count = other.count;
+		[exports.MOVE, function(other, conflictless) {
+		var splice  = [];
+		var pos     = other.pos;
+		var count   = other.count;
 		var new_pos = other.new_pos;
-		var index  = 0;  // iterator over hunks
+		var index   = 0;  // iterator over hunks
 		var changes = 0;  // accumulator of total length change
-		var unmoved = 0; // delta of changes not moving counter 
-		var before = 0;  // length change before RTL MOVE source
+		var unmoved = 0;  // delta of changes not moving counter 
+		var before  = 0;  // length change before RTL MOVE source
 		var ltr = pos < new_pos;
 		this.hunks.forEach(function(hunk) {
 			index += hunk.offset;
@@ -809,13 +809,13 @@ If we have SPLICE hunks in:
 				if (ltr) {
 					splice.push(
 						jot.SPLICE(cursor - (other.count - left), right, ""),
-						jot.SPLICE(other.new_pos - other.count + (cursor - other.pos) - right, left, "")
+						jot.SPLICE(other.new_pos - other.count + (cursor - other.pos) - right, left,  hunk.op.new_value)
 					)
 					count -= left;
 					changes += left;
 				} else {
 					splice.push(
-						jot.SPLICE(other.new_pos + before + (count - left), left, ""),
+						jot.SPLICE(other.new_pos + before + (count - left), left,  hunk.op.new_value),
 						jot.SPLICE(cursor, right, "")
 					)
 					count -= left;

--- a/jot/sequences.js
+++ b/jot/sequences.js
@@ -799,7 +799,7 @@ exports.PATCH.prototype.rebase_functions = [
 					count -= left;
 				}
 			} else {
-				splice.push(new jot.SPLICE(hunk.offset, hunk.length, hunk.op.new_value))
+				splice.push(new jot.SPLICE(index, hunk.length, hunk.op.new_value))
 			}
 		})
 

--- a/jot/sequences.js
+++ b/jot/sequences.js
@@ -759,10 +759,8 @@ If we have SPLICE hunks in:
 		var new_pos = other.new_pos;
 		var index  = 0;  // iterator over hunks
 		var changes = 0;  // accumulator of total length change
-		var removed = 0; // number of skipped characters
 		var unmoved = 0; // delta of changes not moving counter 
 		var before = 0;  // length change before RTL MOVE source
-		var inserted = 0;
 		var ltr = pos < new_pos;
 		this.hunks.forEach(function(hunk) {
 			index += hunk.offset;

--- a/jot/sequences.js
+++ b/jot/sequences.js
@@ -760,12 +760,10 @@ exports.PATCH.prototype.rebase_functions = [
 					)
 				)
 				count -= hunk.length
-				if (ltr) {
+				if (ltr)
 					new_pos -= hunk.length
-				}
-
 			// Splice removes start of moved range
-			} else if (index < pos && index + hunk.length >= pos) {
+			} else if (index < pos && index + hunk.length > pos) {
 				var left = pos - index;
 				var right = hunk.length - left;
 				if (ltr) {
@@ -780,15 +778,14 @@ exports.PATCH.prototype.rebase_functions = [
 				} else {
 					splice.push(
 						jot.SPLICE(new_pos, right,  ""),
-						jot.SPLICE(index + count - left, left, "")
+						jot.SPLICE(index + count - left, left,  "")
 					);
 					count -= left;
 					pos -= left;
-					index += left;
 				}
 
 			// Splice removes end of moved range
-			} else if (index <= pos + count && index + hunk.length > pos + count) {
+			} else if (index < pos + count && index + hunk.length > pos + count) {
 				var left = (pos + count) -  index;
 				var right = hunk.length - left;
 				if (ltr) {
@@ -808,23 +805,21 @@ exports.PATCH.prototype.rebase_functions = [
 
 			// Splice comes after MOVE source region, but before target
 			} else if (index > pos && index < new_pos) {
-				splice.push(new jot.SPLICE(index - count, hunk.length, hunk.op.new_value))
-				index += hunk.length;
+				splice.push(jot.SPLICE(index - count, hunk.length, hunk.op.new_value))
 
 			// Splice comes before MOVE source position but after new position
 			} else if (index < pos && index > new_pos) {
-				splice.push(new jot.SPLICE(index, hunk.length, hunk.op.new_value))
-				index += hunk.length;
+				splice.push(jot.SPLICE(index + count, hunk.length, hunk.op.new_value))
+				pos -= hunk.length
 
 			// Splice outside of range modified by MOVE
 			} else {
-				splice.push(new jot.SPLICE(index, hunk.length, hunk.op.new_value))
-				index += hunk.length;
+				splice.push(jot.SPLICE(index, hunk.length, hunk.op.new_value))
 			}
 		})
 
 		return [
-			new jot.LIST(splice).simplify(), 
+			new jot.LIST(splice.simplify(), 
 			count ? new exports.MOVE(pos, count, new_pos) : new values.NO_OP
 		];
 	}]

--- a/tests/sequences.js
+++ b/tests/sequences.js
@@ -593,18 +593,17 @@ t.deepEqual(jot.SPLICE(12, 2, "").compose(
 
 
 // splice has multiple hunks w RTL MOVE
-expect(jot.SPLICE(10, 2, "")
-.compose(
-	jot.SPLICE(12, 2, "")
+
+t.deepEqual(jot.SPLICE(10, 4, "").compose(
+  new jot.SPLICE(12, 2, "")
 ).compose(
   new jot.SPLICE(14, 2, "")
 ).compose(
   new jot.SPLICE(16, 2, "")
 ).rebase(
   new jot.MOVE(13, 9, 3), true
-).apply(new jot.MOVE(13, 9, 3).apply('ABCDEFGHIJKLMNOPQRSTUVWXYZ'))
-  .to.eql('ABCNQRUVDEFGHIJMYZ')
-
+).apply(new jot.MOVE(13, 9, 3).apply('ABCDEFGHIJKLMNOPQRSTUVWXYZ')),
+  'ABCOPSTDEFGHIJWX');
 t.end();
 
 });

--- a/tests/sequences.js
+++ b/tests/sequences.js
@@ -534,10 +534,8 @@ t.deepEqual(new jot.MOVE(5, 5, 13).rebase(
   new jot.MOVE(2, 2, 7)
 )
 
-var rebased = new jot.SPLICE(3, 7, "").rebase(
-  new jot.MOVE(0, 9, 23), true
-);
-t.deepEqual(rebased,
+t.deepEqual(new jot.SPLICE(3, 7, "").rebase(
+  new jot.MOVE(0, 9, 23), true),
   jot.SPLICE(0, 1, "").compose(
     jot.SPLICE(16, 6, "")
   )

--- a/tests/sequences.js
+++ b/tests/sequences.js
@@ -6,7 +6,6 @@ var jot = require("../jot");
 test('sequences', function(t) {
 
 // inspect
-
 t.equal(
 	new seqs.SPLICE(0, 1, "4").inspect(),
 	'<sequences.PATCH +0x1 "4">');
@@ -354,18 +353,15 @@ t.notOk(
 t.deepEqual(
 	new seqs.APPLY(555, new values.SET("y")).rebase(
 		new seqs.APPLY(555, new values.SET("z")), true),
-	new values.NO_OP()
-	)
+	new values.NO_OP())
 t.deepEqual(
 	new seqs.APPLY(555, new values.SET("z")).rebase(
 		new seqs.APPLY(555, new values.SET("y")), true),
-	new seqs.APPLY(555, new values.SET("z"))
-	)
+	new seqs.APPLY(555, new values.SET("z")))
 t.deepEqual(
 	new seqs.APPLY({0: new values.SET("z"), 1: new values.SET("b"), 2: new values.SET("N")}).rebase(
 		new seqs.APPLY({0: new values.SET("y"), 1: new values.SET(" ")}), true),
-	new seqs.APPLY({0: new values.SET("z"), 1: new values.SET("b"), 2: new values.SET("N")})
-	)
+	new seqs.APPLY({0: new values.SET("z"), 1: new values.SET("b"), 2: new values.SET("N")}))
 
 // apply vs move
 
@@ -402,7 +398,6 @@ t.notOk(
 		new seqs.MAP(new values.MATH("mult", 3))));
 
 
-
 // splice vs move
 
 // splice partially remove beginning of LTR MOVE range
@@ -410,103 +405,85 @@ t.deepEqual(
   new jot.SPLICE(0, 2, "").rebase(
     new jot.MOVE(1, 2, 4), true),
   new jot.SPLICE(0, 1, "").compose(
-  new jot.SPLICE(1, 1, ""))
-)
+  new jot.SPLICE(1, 1, "")))
 t.deepEqual(
   new jot.MOVE(1, 2, 4).rebase(
     new jot.SPLICE(0, 2, ""), true),
-  new jot.MOVE(0, 1, 2)
-)
+  new jot.MOVE(0, 1, 2))
 
 t.deepEqual(new jot.SPLICE(2, 6, "").rebase(
     new jot.MOVE(5, 5, 13), true),
   new jot.SPLICE(2, 3, "").compose(
-  	new jot.SPLICE(5, 3, ""))
-)
+  	new jot.SPLICE(5, 3, "")))
 
 t.deepEqual(new jot.MOVE(5, 5, 13).rebase(
     new jot.SPLICE(2, 6, ""), true),
-  new jot.MOVE(2, 2, 7)
-)
+  new jot.MOVE(2, 2, 7))
 
 // splice partially remove beginning of RTL MOVE range
 t.deepEqual(
   new jot.SPLICE(4, 2, "").rebase(
    new jot.MOVE(5, 2, 1), true),
   new jot.SPLICE(1, 1, "").compose(
-    new jot.SPLICE(5, 1, "")
-  )
-)
+    new jot.SPLICE(5, 1, "")))
 
 t.deepEqual(
   new jot.MOVE(5, 2, 1).rebase(
     new jot.SPLICE(4, 2, ""), true),
-  new jot.MOVE(4, 1, 1)
-)
+  new jot.MOVE(4, 1, 1))
 
 t.deepEqual(new jot.MOVE(6, 5, 2).rebase(
     new jot.SPLICE(3, 6, ""), true),
-  new jot.MOVE(3, 2, 2)
-)
+  new jot.MOVE(3, 2, 2))
 
 // splice removes whole LTR MOVE range
 t.deepEqual(
   new jot.SPLICE(0, 2, "").rebase(
     new jot.MOVE(0, 2, 4), true),
-  new jot.SPLICE(2, 2, "")
-)
+  new jot.SPLICE(2, 2, ""))
 t.deepEqual(
   new jot.MOVE(0, 2, 4).rebase(
     new jot.SPLICE(0, 2, ""), true),
-  new jot.NO_OP
-)
+  new jot.NO_OP)
 
 // splice removes whole RTL MOVE range
 t.deepEqual(
   new jot.SPLICE(4, 2, "").rebase(
     new jot.MOVE(4, 2, 0), true),
-  new jot.SPLICE(0, 2, "")
-)
+  new jot.SPLICE(0, 2, ""))
 t.deepEqual(
   new jot.MOVE(4, 2, 0).rebase(
     new jot.SPLICE(4, 2, ""), true),
-  new jot.NO_OP
-)
+  new jot.NO_OP)
 
 // splice is within RTL MOVE range
 t.deepEqual(
   new jot.SPLICE(4, 3, "").rebase(
     new jot.MOVE(4, 7, 0), true),
-  new jot.SPLICE(0, 3, "")
-)
+  new jot.SPLICE(0, 3, ""))
 t.deepEqual(
   new jot.MOVE(4, 7, 0).rebase(
     new jot.SPLICE(4, 3, ""), true),
-  new jot.MOVE(4, 4, 0)
-)
+  new jot.MOVE(4, 4, 0))
 
 
 // splice is within LTR MOVE range
 t.deepEqual(
   new jot.SPLICE(1, 2, "").rebase(
     new jot.MOVE(0, 4, 4), true),
-  new jot.SPLICE(1, 2, "")
-)
+  new jot.SPLICE(1, 2, ""))
 t.deepEqual(
   new jot.SPLICE(1, 2, "").rebase(
     new jot.MOVE(0, 4, 5), true),
-  new jot.SPLICE(2, 2, "")
-)
+  new jot.SPLICE(2, 2, ""))
 t.deepEqual(
   new jot.MOVE(0, 4, 6).rebase(
     new jot.SPLICE(1, 2, ""), true),
-  new jot.MOVE(0, 2, 4)
-)
+  new jot.MOVE(0, 2, 4))
 t.deepEqual(
   new jot.MOVE(0, 2, 4).rebase(
     new jot.SPLICE(0, 2, ""), true),
-  new jot.NO_OP
-)
+  new jot.NO_OP)
 
 // splice partially removes end of LTR MOVE range
 
@@ -514,32 +491,25 @@ t.deepEqual(
   new jot.SPLICE(1, 2, "").rebase(
     new jot.MOVE(0, 2, 4), true),
   new jot.SPLICE(0, 1, "").compose(
-    new jot.SPLICE(2, 1, "")
-  )
-)
+    new jot.SPLICE(2, 1, "")))
 t.deepEqual(
   new jot.MOVE(0, 2, 4).rebase(
     new jot.SPLICE(1, 2, ""), true),
-  new jot.MOVE(0, 1, 2)
-)
+  new jot.MOVE(0, 1, 2))
 
 t.deepEqual(new jot.SPLICE(6, 5, "").rebase(
     new jot.MOVE(4, 5, 13), true),
   new jot.SPLICE(4, 2, "").compose(
-  new jot.SPLICE(8, 3, ""))
-)
+  new jot.SPLICE(8, 3, "")))
 
 t.deepEqual(new jot.MOVE(5, 5, 13).rebase(
     new jot.SPLICE(2, 6, ""), true),
-  new jot.MOVE(2, 2, 7)
-)
+  new jot.MOVE(2, 2, 7))
 
 t.deepEqual(new jot.SPLICE(3, 7, "").rebase(
   new jot.MOVE(0, 9, 23), true),
   jot.SPLICE(0, 1, "").compose(
-    jot.SPLICE(16, 6, "")
-  )
-)
+    jot.SPLICE(16, 6, "")))
 
 //splice partially removes end of RTL MOVE range
 
@@ -547,36 +517,28 @@ t.deepEqual(
   new jot.SPLICE(6, 2, "").rebase(
     new jot.MOVE(5, 2, 1), true),
   new jot.SPLICE(2, 1, "").compose(
-    new jot.SPLICE(6, 1, "")
-  )
-)
+    new jot.SPLICE(6, 1, "")))
 t.deepEqual(
   new jot.MOVE(0, 2, 4).rebase(
     new jot.SPLICE(1, 2, ""), true),
-  new jot.MOVE(0, 1, 2)
-)
+  new jot.MOVE(0, 1, 2))
 
 t.deepEqual(
   new jot.SPLICE(6, 6, "").rebase(
     new jot.MOVE(4, 5, 2), true),
   new jot.SPLICE(4, 3, '').compose(
-    new jot.SPLICE(6, 3, '')
-  )
-)
+    new jot.SPLICE(6, 3, '')))
 
 t.deepEqual(
   new jot.SPLICE(6, 7, "").rebase(
     new jot.MOVE(4, 5, 2), true),
   new jot.SPLICE(4, 3, '').compose(
-    new jot.SPLICE(6, 4, '')
-  )
-)
+    new jot.SPLICE(6, 4, '')))
 
 t.deepEqual(new jot.MOVE(4, 5, 2).rebase(
   new jot.SPLICE(6, 6, ""), true
 ),
-  new jot.MOVE(4, 2, 2)
-)
+  new jot.MOVE(4, 2, 2))
 
 
 // splice has multiple hunks w LTR MOVE
@@ -587,8 +549,7 @@ t.deepEqual(jot.SPLICE(3, 7, "").compose(
 ),
   jot.SPLICE(0, 1, "").compose(
     jot.SPLICE(8, 3, "").compose(
-    jot.SPLICE(13, 6, "")))
-)
+    jot.SPLICE(13, 6, ""))))
 t.deepEqual(jot.SPLICE(3, 7, "").compose(
   new jot.SPLICE(8, 3, "")
 ).rebase(
@@ -603,6 +564,24 @@ t.deepEqual(jot.SPLICE(3, 7, "").compose(
   new jot.MOVE(0, 9, 23), true
 ).apply('JKLMNOPQRSTUVWABCDEFGHIXYZ'),'KLMNOVWABCXYZ')
 
+t.deepEqual(jot.SPLICE(2, 2, "").compose(
+  new jot.SPLICE(4, 2, "")
+).compose(
+  new jot.SPLICE(6, 2, "")
+).rebase(
+  new jot.MOVE(0, 9, 23), true
+),
+  jot.SPLICE(1, 2, "").compose(
+    jot.SPLICE(14, 2, "").compose(
+      jot.SPLICE(16, 2, ""))))
+
+t.deepEqual(jot.SPLICE(2, 2, "").compose(
+  new jot.SPLICE(4, 2, "")
+).compose(
+  new jot.SPLICE(6, 2, "")
+).rebase(
+  new jot.MOVE(0, 9, 23), true
+).apply('JKLMNOPQRSTUVWABCDEFGHIXYZ'), 'JMNOPQRSTUVWABEFIXYZ')
 t.end();
 
 });

--- a/tests/sequences.js
+++ b/tests/sequences.js
@@ -401,6 +401,210 @@ t.notOk(
 	new seqs.MAP(new values.MATH("add", 1)).rebase(
 		new seqs.MAP(new values.MATH("mult", 3))));
 
+
+
+// splice vs move
+
+// splice partially remove beginning of LTR MOVE range
+t.deepEqual(
+  new jot.SPLICE(0, 2, "").rebase(
+    new jot.MOVE(1, 2, 4), true),
+  new jot.SPLICE(0, 1, "").compose(
+  new jot.SPLICE(1, 1, ""))
+)
+t.deepEqual(
+  new jot.MOVE(1, 2, 4).rebase(
+    new jot.SPLICE(0, 2, ""), true),
+  new jot.MOVE(0, 1, 2)
+)
+
+t.deepEqual(new jot.SPLICE(2, 6, "").rebase(
+    new jot.MOVE(5, 5, 13), true),
+  new jot.SPLICE(2, 3, "").compose(
+  	new jot.SPLICE(5, 3, ""))
+)
+
+t.deepEqual(new jot.MOVE(5, 5, 13).rebase(
+    new jot.SPLICE(2, 6, ""), true),
+  new jot.MOVE(2, 2, 7)
+)
+
+// splice partially remove beginning of RTL MOVE range
+t.deepEqual(
+  new jot.SPLICE(4, 2, "").rebase(
+   new jot.MOVE(5, 2, 1), true),
+  new jot.SPLICE(1, 1, "").compose(
+    new jot.SPLICE(5, 1, "")
+  )
+)
+
+t.deepEqual(
+  new jot.MOVE(5, 2, 1).rebase(
+    new jot.SPLICE(4, 2, ""), true),
+  new jot.MOVE(4, 1, 1)
+)
+
+t.deepEqual(new jot.MOVE(6, 5, 2).rebase(
+    new jot.SPLICE(3, 6, ""), true),
+  new jot.MOVE(3, 2, 2)
+)
+
+// splice removes whole LTR MOVE range
+t.deepEqual(
+  new jot.SPLICE(0, 2, "").rebase(
+    new jot.MOVE(0, 2, 4), true),
+  new jot.SPLICE(2, 2, "")
+)
+t.deepEqual(
+  new jot.MOVE(0, 2, 4).rebase(
+    new jot.SPLICE(0, 2, ""), true),
+  new jot.NO_OP
+)
+
+// splice removes whole RTL MOVE range
+t.deepEqual(
+  new jot.SPLICE(4, 2, "").rebase(
+    new jot.MOVE(4, 2, 0), true),
+  new jot.SPLICE(0, 2, "")
+)
+t.deepEqual(
+  new jot.MOVE(4, 2, 0).rebase(
+    new jot.SPLICE(4, 2, ""), true),
+  new jot.NO_OP
+)
+
+// splice is within RTL MOVE range
+t.deepEqual(
+  new jot.SPLICE(4, 3, "").rebase(
+    new jot.MOVE(4, 7, 0), true),
+  new jot.SPLICE(0, 3, "")
+)
+t.deepEqual(
+  new jot.MOVE(4, 7, 0).rebase(
+    new jot.SPLICE(4, 3, ""), true),
+  new jot.MOVE(4, 4, 0)
+)
+
+
+// splice is within LTR MOVE range
+t.deepEqual(
+  new jot.SPLICE(1, 2, "").rebase(
+    new jot.MOVE(0, 4, 4), true),
+  new jot.SPLICE(1, 2, "")
+)
+t.deepEqual(
+  new jot.SPLICE(1, 2, "").rebase(
+    new jot.MOVE(0, 4, 5), true),
+  new jot.SPLICE(2, 2, "")
+)
+t.deepEqual(
+  new jot.MOVE(0, 4, 6).rebase(
+    new jot.SPLICE(1, 2, ""), true),
+  new jot.MOVE(0, 2, 4)
+)
+t.deepEqual(
+  new jot.MOVE(0, 2, 4).rebase(
+    new jot.SPLICE(0, 2, ""), true),
+  new jot.NO_OP
+)
+
+// splice partially removes end of LTR MOVE range
+
+t.deepEqual(
+  new jot.SPLICE(1, 2, "").rebase(
+    new jot.MOVE(0, 2, 4), true),
+  new jot.SPLICE(0, 1, "").compose(
+    new jot.SPLICE(2, 1, "")
+  )
+)
+t.deepEqual(
+  new jot.MOVE(0, 2, 4).rebase(
+    new jot.SPLICE(1, 2, ""), true),
+  new jot.MOVE(0, 1, 2)
+)
+
+t.deepEqual(new jot.SPLICE(6, 5, "").rebase(
+    new jot.MOVE(4, 5, 13), true),
+  new jot.SPLICE(4, 2, "").compose(
+  new jot.SPLICE(8, 3, ""))
+)
+
+t.deepEqual(new jot.MOVE(5, 5, 13).rebase(
+    new jot.SPLICE(2, 6, ""), true),
+  new jot.MOVE(2, 2, 7)
+)
+
+var rebased = new jot.SPLICE(3, 7, "").rebase(
+  new jot.MOVE(0, 9, 23), true
+);
+t.deepEqual(rebased,
+  jot.SPLICE(0, 1, "").compose(
+    jot.SPLICE(16, 6, "")
+  )
+)
+
+//splice partially removes end of RTL MOVE range
+
+t.deepEqual(
+  new jot.SPLICE(6, 2, "").rebase(
+    new jot.MOVE(5, 2, 1), true),
+  new jot.SPLICE(2, 1, "").compose(
+    new jot.SPLICE(6, 1, "")
+  )
+)
+t.deepEqual(
+  new jot.MOVE(0, 2, 4).rebase(
+    new jot.SPLICE(1, 2, ""), true),
+  new jot.MOVE(0, 1, 2)
+)
+
+t.deepEqual(
+  new jot.SPLICE(6, 6, "").rebase(
+    new jot.MOVE(4, 5, 2), true),
+  new jot.SPLICE(4, 3, '').compose(
+    new jot.SPLICE(6, 3, '')
+  )
+)
+
+t.deepEqual(
+  new jot.SPLICE(6, 7, "").rebase(
+    new jot.MOVE(4, 5, 2), true),
+  new jot.SPLICE(4, 3, '').compose(
+    new jot.SPLICE(6, 4, '')
+  )
+)
+
+t.deepEqual(new jot.MOVE(4, 5, 2).rebase(
+  new jot.SPLICE(6, 6, ""), true
+),
+  new jot.MOVE(4, 2, 2)
+)
+
+
+// splice has multiple hunks w LTR MOVE
+t.deepEqual(jot.SPLICE(3, 7, "").compose(
+  new jot.SPLICE(11, 3, "")
+).rebase(
+  new jot.MOVE(0, 9, 23), true
+),
+  jot.SPLICE(0, 1, "").compose(
+    jot.SPLICE(8, 3, "").compose(
+    jot.SPLICE(13, 6, "")))
+)
+t.deepEqual(jot.SPLICE(3, 7, "").compose(
+  new jot.SPLICE(8, 3, "")
+).rebase(
+  new jot.MOVE(0, 9, 23), true
+).apply('JKLMNOPQRSTUVWABCDEFGHIXYZ'),'KLMNOSTUVWABCXYZ')
+
+t.deepEqual(jot.SPLICE(3, 7, "").compose(
+  new jot.SPLICE(11, 3, "")
+).compose(
+  new jot.SPLICE(8, 3, "")
+).rebase(
+  new jot.MOVE(0, 9, 23), true
+).apply('JKLMNOPQRSTUVWABCDEFGHIXYZ'),'KLMNOVWABCXYZ')
+
 t.end();
 
 });

--- a/tests/sequences.js
+++ b/tests/sequences.js
@@ -582,6 +582,29 @@ t.deepEqual(jot.SPLICE(2, 2, "").compose(
 ).rebase(
   new jot.MOVE(0, 9, 23), true
 ).apply('JKLMNOPQRSTUVWABCDEFGHIXYZ'), 'JMNOPQRSTUVWABEFIXYZ')
+
+t.deepEqual(jot.SPLICE(12, 2, "").compose(
+  new jot.SPLICE(14, 2, "")
+).compose(
+  new jot.SPLICE(16, 2, "")
+).rebase(
+  new jot.MOVE(13, 9, 3), true
+).apply('ABCDEFGHIJKLMWXYZ'), 'ABCNOPQRSTUVWXYZ')
+
+
+// splice has multiple hunks w RTL MOVE
+expect(jot.SPLICE(10, 2, "")
+.compose(
+	jot.SPLICE(12, 2, "")
+).compose(
+  new jot.SPLICE(14, 2, "")
+).compose(
+  new jot.SPLICE(16, 2, "")
+).rebase(
+  new jot.MOVE(13, 9, 3), true
+).apply(new jot.MOVE(13, 9, 3).apply('ABCDEFGHIJKLMNOPQRSTUVWXYZ'))
+  .to.eql('ABCNQRUVDEFGHIJMYZ')
+
 t.end();
 
 });


### PR DESCRIPTION
This is a work in progress, **not** ready for merge. I'm opening up this PR early to get possible feedback early, and to track the progress to avoid duplicated work during refactoring.

- [X] Rebase DEL-like patches against MOVE 
- [x] Rebase multiple-hunk splices against MOVE 
- [x] Rebase INS/replace against MOVE 
- [ ] Rebase MOVE against other types
- [ ] Generate MOVE operations in jot.diff() 

I think the base algorithm is ready. I followed TDD approach, but I think we need tests to be more exhaustive, so I'll double that amount at least.

Hopefully the code in itself makes the basic idea visible (tried to be rather clear than smart). I split SPLICE ops in two wherever they intersect with MOVE range. I considered LTR/RTL MOVE commands, but there is still a bunch of things that need to be looked into, mostly related to inserting text which I did not account for at all yet. I tried to make the code as simple as possible, but I do however rely on simplify() call to combine SPLICE operations again.